### PR TITLE
Make `returnDirect` required

### DIFF
--- a/src/api/types/AppModelsRequestTool.ts
+++ b/src/api/types/AppModelsRequestTool.ts
@@ -7,5 +7,5 @@ export interface AppModelsRequestTool {
     description: string;
     type: string;
     metadata?: Record<string, unknown>;
-    returnDirect?: boolean;
+    returnDirect: boolean;
 }


### PR DESCRIPTION
I've updated the types for `AppModelsRequestTool` and made `returnDirect` required as per the documentation